### PR TITLE
fix(stale): never auto-close — label only (days-before-close: -1)

### DIFF
--- a/.github/workflows/stale-management.yml
+++ b/.github/workflows/stale-management.yml
@@ -24,7 +24,7 @@ jobs:
             # Issue settings
           stale-issue-message: |
             This issue has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 7 days if no further activity occurs.
+            recent activity. It will remain open — this label is informational only; this project never auto-closes.
 
             If this issue is still relevant, please:
             - Add a comment to keep it open
@@ -39,7 +39,7 @@ jobs:
             with updated information.
 
           days-before-stale: 60
-          days-before-close: 7
+          days-before-close: -1
           stale-issue-label: stale
           exempt-issue-labels:
             keep-open,bug,security,critical
@@ -47,7 +47,7 @@ jobs:
             # Pull request settings
           stale-pr-message: |
             This pull request has been automatically marked as stale because it has not had
-            recent activity. It will be closed in 14 days if no further activity occurs.
+            recent activity. It will remain open — this label is informational only; this project never auto-closes.
 
             If this PR is still relevant, please:
             - Rebase on the latest main/master branch
@@ -63,7 +63,7 @@ jobs:
             a new one with updated changes.
 
           days-before-pr-stale: 30
-          days-before-pr-close: 14
+          days-before-pr-close: -1
           stale-pr-label: stale
           exempt-pr-labels:
             keep-open,security,critical,in-progress


### PR DESCRIPTION
The stale workflow auto-closed issues/PRs, violating this universe's absolute doctrine: we never close, dismiss, or delete — if it was ever asked for it was wanted.

Sets the close window to -1 (never-close), preserving the informational label. This file was missed by the first sweep (non-standard name/path/extension).